### PR TITLE
Gather all names before printing them.

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -26,6 +26,7 @@ type MMirc struct {
 	i           *irc.Connection
 	ircNick     string
 	ircNickPass string
+	names       []string
 }
 
 type MMMessage struct {
@@ -41,7 +42,6 @@ type Bridge struct {
 	*Config
 	ircMap map[string]string
 	kind   string
-	names  []string
 }
 
 func NewBridge(name string, config *Config, kind string) *Bridge {
@@ -151,13 +151,13 @@ func (b *Bridge) formatnicks(nicks []string) string {
 }
 
 func (b *Bridge) storeNames(event *irc.Event) {
-       b.names = append(b.names, strings.Split(event.Message(), " ")...)
+       b.MMirc.names = append(b.MMirc.names, strings.Split(event.Message(), " ")...)
 }
 
 func (b *Bridge) endNames(event *irc.Event) {
-       sort.Strings(b.names)
-       b.Send(b.ircNick, b.formatnicks(b.names), b.getMMChannel(event.Arguments[0]))
-       b.names = nil
+       sort.Strings(b.MMirc.names)
+       b.Send(b.ircNick, b.formatnicks(b.MMirc.names), b.getMMChannel(event.Arguments[0]))
+       b.MMirc.names = nil
 }
 
 func (b *Bridge) handleOther(event *irc.Event) {

--- a/bridge/helper.go
+++ b/bridge/helper.go
@@ -4,8 +4,7 @@ import (
 	"strings"
 )
 
-func tableformatter(nicks_s string, nicksPerRow int) string {
-	nicks := strings.Split(nicks_s, " ")
+func tableformatter(nicks []string, nicksPerRow int) string {
 	result := "|IRC users"
 	if nicksPerRow < 1 {
 		nicksPerRow = 4
@@ -31,8 +30,8 @@ func tableformatter(nicks_s string, nicksPerRow int) string {
 	return result
 }
 
-func plainformatter(nicks string, nicksPerRow int) string {
-	return nicks + " currently on IRC"
+func plainformatter(nicks []string, nicksPerRow int) string {
+	return strings.Join(nicks, ", ") + " currently on IRC"
 }
 
 func IsMarkup(message string) bool {


### PR DESCRIPTION
When issuing a NAMES request, the reponse is chunked. Cache names
until all are received, then print them out.
