### PR TITLE
Gather all names before printing them.

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -9,6 +9,7 @@ import (
 	"github.com/thoj/go-ircevent"
 	"strconv"
 	"strings"
+	"sort"
 )
 
 //type Bridge struct {
@@ -25,6 +26,7 @@ type MMirc struct {
 	i       *irc.Connection
 	ircNick string
 	ircMap  map[string]string
+	names   []string
 }
 
 type MMMessage struct {
@@ -138,7 +140,7 @@ func (b *Bridge) handleNotice(event *irc.Event) {
 	}
 }
 
-func (b *Bridge) formatnicks(nicks string) string {
+func (b *Bridge) formatnicks(nicks []string) string {
 	switch b.Config.Mattermost.NickFormatter {
 	case "table":
 		return tableformatter(nicks, b.Config.Mattermost.NicksPerRow)
@@ -147,13 +149,24 @@ func (b *Bridge) formatnicks(nicks string) string {
 	}
 }
 
+func (b *Bridge) storeNames(event *irc.Event) {
+       b.MMirc.names = append(b.MMirc.names, strings.Split(event.Message(), " ")...)
+}
+
+func (b *Bridge) endNames(event *irc.Event) {
+       sort.Strings(b.MMirc.names)
+       b.Send(b.ircNick, b.formatnicks(b.MMirc.names), b.getMMChannel(event.Arguments[2]))
+       b.MMirc.names = nil
+}
+
 func (b *Bridge) handleOther(event *irc.Event) {
 	switch event.Code {
 	case "001":
 		b.handleNewConnection(event)
+	case "366":
+		b.endNames(event)
 	case "353":
-		log.Debug("handleOther ", b.getMMChannel(event.Arguments[2]))
-		b.Send(b.ircNick, b.formatnicks(event.Message()), b.getMMChannel(event.Arguments[2]))
+		b.storeNames(event)
 	case "NOTICE":
 		b.handleNotice(event)
 	default:
@@ -243,6 +256,7 @@ func (b *Bridge) handleMatter() {
 		}
 		texts := strings.Split(message.Text, "\n")
 		for _, text := range texts {
+			log.Debug("Sending message from " + message.Username + " to " + message.Channel)
 			b.i.Privmsg(b.getIRCChannel(message.Channel), username+text)
 		}
 	}

--- a/bridge/helper.go
+++ b/bridge/helper.go
@@ -4,8 +4,7 @@ import (
 	"strings"
 )
 
-func tableformatter(nicks_s string, nicksPerRow int) string {
-	nicks := strings.Split(nicks_s, " ")
+func tableformatter(nicks []string, nicksPerRow int) string {
 	result := "|IRC users"
 	if nicksPerRow < 1 {
 		nicksPerRow = 4
@@ -31,8 +30,8 @@ func tableformatter(nicks_s string, nicksPerRow int) string {
 	return result
 }
 
-func plainformatter(nicks string, nicksPerRow int) string {
-	return nicks + " currently on IRC"
+func plainformatter(nicks []string, nicksPerRow int) string {
+	return strings.Join(nicks, ", ") + " currently on IRC"
 }
 
 func IsMarkup(message string) bool {


### PR DESCRIPTION
When issuing a NAMES request, the reponse is chunked. Cache names
until all are received, then print them out.
