### PR TITLE
Trim the nicks before splitting

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -150,7 +150,7 @@ func (b *Bridge) formatnicks(nicks []string) string {
 }
 
 func (b *Bridge) storeNames(event *irc.Event) {
-	b.MMirc.names = append(b.MMirc.names, strings.Split(event.Message(), " ")...)
+	b.MMirc.names = append(b.MMirc.names, strings.Split(strings.TrimSpace(event.Message()), " ")...)
 }
 
 func (b *Bridge) endNames(event *irc.Event) {


### PR DESCRIPTION
Whitespace can cause issues here, we're seeing leading commas on join:

```
irc-mmbridgedev joins #MMDev 11:18
, @mmbridgedev currently on IRC
```
