### PR TITLE
Chunk NAMES output if too long.

### DIFF
--- a/bridge/helper.go
+++ b/bridge/helper.go
@@ -4,10 +4,10 @@ import (
 	"strings"
 )
 
-func tableformatter(nicks []string, nicksPerRow int) string {
+func tableformatter(nicks []string, nicksPerRow int, continued bool) string {
 	result := "|IRC users"
-	if nicksPerRow < 1 {
-		nicksPerRow = 4
+	if continued {
+		result = "|(continued)"
 	}
 	for i := 0; i < 2; i++ {
 		for j := 1; j <= nicksPerRow && j <= len(nicks); j++ {


### PR DESCRIPTION
If the list of nicks on IRC is too long, it can't be posted to
Mattermost in one go. In those cases, split it up into chunks.
