### PR TITLE
Add example and comment explaining naming of channels.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,10 @@ mattermost="testing"
 [channel "random channel"]
 irc="#random"
 mattermost="random"
+
+[channel "town square"]
+irc="#square"
+# Note that the name given here must correspond to the URL of the
+# channel, not it's display name.
+mattermost="town-square"
 ```


### PR DESCRIPTION
I ran into the issue that I configured the display name in the config,
and matterbridge-plus would not relay any messages between IRC and MM.

See #27 where I ran into a problem due to not knowing this
